### PR TITLE
need to remove the margin-left: 200px style on row in skills

### DIFF
--- a/_includes/services.html
+++ b/_includes/services.html
@@ -10,7 +10,7 @@
                 </div>
             </div>
             <div class="container">
-                <div class="row"  style="margin-left:200px">
+                <div class="row">
                     <div class="col-lg-3 col-md-6 text-center">
                         <div class="service-box">
                             <i class="fa fa-4x fa-diamond wow bounceIn text-primary"></i>


### PR DESCRIPTION
If you remove this and add the changes to the agency.css file that i sent a pull request for this will fix the wierd positioning of your skills when resizing the screen.
